### PR TITLE
Use relative paths instead of Pkg.dir()

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,7 +3,7 @@
 
 # function getfile(fname)
 # 	url = "http://cdn.pydata.org/" * fname
-# 	path = Pkg.dir("Bokeh", "deps", "bokehjs", fname)
+# 	path = joinpath(dirname(@__FILE__), "bokehjs", fname))
 # 	println("downloading from $url to $path")
 # 	download(url, path)
 # end

--- a/docs/examples/build_all.jl
+++ b/docs/examples/build_all.jl
@@ -3,7 +3,7 @@ using Bokeh
 Bokeh.includejs(true)  # this is required as these files will be published online
 Bokeh.noshow(true)
 Bokeh.filewarnings(false)
-exdir = Pkg.dir("Bokeh", "docs", "examples")
+exdir = dirname(@__FILE__)
 cd(exdir)
 for jl_src in filter(f -> endswith(f, ".jl") && f != "build_all.jl", readdir(exdir))
 	glyphsize(6)

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -152,7 +152,7 @@ function _gettemplate(template::String, path::Union(String, Nothing)=nothing)
 end
 
 function _bokehjs_paths(minified::Bool=true)
-    dir = Pkg.dir("Bokeh", "deps", "bokehjs")
+    dir = joinpath(dirname(@__FILE__), "..", "deps", "bokehjs")
     jspath = joinpath(dir, minified ? "bokeh.min.js" : "bokeh.js")
     csspath = joinpath(dir, minified ? "bokeh.min.css" : "bokeh.css")
     (jspath, csspath)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Bokeh
 using Base.Test
 
 # check js and css files are there (in case they've been downloaded)
-bkfiles = readdir(Pkg.dir("Bokeh", "deps", "bokehjs"))
+bkfiles = readdir(joinpath(dirname(@__FILE__), "..", "deps", "bokehjs"))
 @test length(filter(x -> endswith(x, ".js"), bkfiles))  == 2
 @test length(filter(x -> endswith(x, ".css"), bkfiles)) == 2
 


### PR DESCRIPTION
`Pkg.dir()` won't work if Bokeh is installed outside the standard package location, so use relative paths instead to access other files in the package. See https://github.com/JuliaLang/julia/issues/8679#issuecomment-75796502