### PR TITLE
Fix JSON.jl _print deprecation

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.4-
 Mustache
-JSON 0.4
+JSON 0.7
 Dates 0.3.2

--- a/src/bokehjs.jl
+++ b/src/bokehjs.jl
@@ -294,17 +294,13 @@ typealias NullSymbol Bokehjs.NullSymbol
 typealias NullFloat Bokehjs.NullFloat
 typealias NullInt Bokehjs.NullInt
 
-JSON._print(io::IO, state::JSON.State, uuid::Bokehjs.UUID) =
-    JSON._print(io, state, string(uuid))
+JSON.lower(uuid::Bokehjs.UUID) = string(uuid)
 
-function JSON._print(io::IO, state::JSON.State, tid::Bokehjs.TypeID)
-    tid.plotob == nothing && (return JSON._print(io, state, nothing))
+function JSON.lower(tid::Bokehjs.TypeID)
+    tid.plotob == nothing && return nothing
     attrs = fieldnames(tid.plotob)
     obtype = in(:_type_name, attrs) ? tid.plotob._type_name : typeof(tid.plotob)
-    d = Dict{AbstractString, BkAny}("type" => obtype, "id" => tid.plotob.uuid)
-    JSON._print(io, state, d)
+    Dict{AbstractString, BkAny}("type" => obtype, "id" => tid.plotob.uuid)
 end
 
-function JSON._print{T<:Bokehjs.PlotObject}(io::IO, state::JSON.State, d::Type{T})
-    Base.print(io, "\"", d.name.name, "\"")
-end
+JSON.lower{T<:Bokehjs.PlotObject}(::Type{T}) = string(T.name.name)


### PR DESCRIPTION
JSON.lower has been introduced to replace JSON._print, whose overloads will be deprecated in JSON v0.7.0, and will be removed in the future. See https://github.com/JuliaLang/METADATA.jl/pull/5988 for the PR introducing the v0.7.0 tag. I would recommend not merging until the tag is actually merged (it's temporarily stalled because of plans to drop v0.3 support.)
